### PR TITLE
Fixed file path on jshint configuration and removed karma task

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -60,7 +60,7 @@ module.exports = function(grunt) {
           jshintrc: '.jshintrc'
         },
         files: {
-          src: ['src/**/*/.js']
+          src: ['src/**/*.js']
         }
       }
     },
@@ -112,6 +112,6 @@ module.exports = function(grunt) {
 
   require('load-grunt-tasks')(grunt);
 
-  grunt.registerTask('default', ['jshint', 'karma', 'clean', 'concat', 'babel', 'copy', 'sass']);
+  grunt.registerTask('default', ['jshint', 'clean', 'concat', 'babel', 'copy', 'sass']);
 
 };


### PR DESCRIPTION
Fixed file path on the jshint configuration and removed the karma task from grunt "default" array. 