### PR TITLE
Removed ng-controller line in the login template because the state regarding login in the module cover this functionality

### DIFF
--- a/src/views/login.template.html
+++ b/src/views/login.template.html
@@ -1,4 +1,4 @@
-<section ng-controller='LoginController as loginCtrl'>
+<section>
     <h2>Staff Log In</h2>
     <p ng-show='loginCtrl.hasError' class='alert alert-warning'>{{loginCtrl.message}}</p>
     <form name='staff-login'


### PR DESCRIPTION
I removed the line ng-controller='LoginController as loginCtrl' from the section tag on the login.template.html because its functionality is handled by the states in the module.